### PR TITLE
Update sha in metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,9 @@
 homepage: "https://zuko.io"
 documentation: "https://zuko.io/guides/install-zuko-tracking-tags-in-google-tag-manager"
 versions:
+  # Latest version
+  - sha: 50903fededd9008626e5174a242e65e9878549bb
+    changeNotes: Add required files.
+  # Older versions
   - sha: 3d4cabead4be566647eece6c4687b7bef0a2e23a
     changeNotes: Initial release.


### PR DESCRIPTION
(Similar to the activity change https://github.com/ZukoAnalytics/gtm-template-activity/pull/3)

The current sha in this file is when the repo only contained the template. Since then, the README and metadata files were added.

So if GTM are looking at our repo only from that initial release sha (3d4cabead4be566647eece6c4687b7bef0a2e23a), they wouldn't see some other required files.